### PR TITLE
Sized signals

### DIFF
--- a/bayeux.cabal
+++ b/bayeux.cabal
@@ -20,6 +20,7 @@ library
                     , Bayeux.Lp
                     , Bayeux.Rgb
                     , Bayeux.Rtl
+                    , Bayeux.Signal
                     , Bayeux.Tableaux
                     , Bayeux.Uart
     other-modules:    Paths_bayeux

--- a/lib/Bayeux.hs
+++ b/lib/Bayeux.hs
@@ -27,7 +27,7 @@ app = \case
     FiatLux    -> flow iceprog "FiatLux" fiatLux =<< getDataFileName ("data" </> "FiatLux" <.> "pcf")
     RgbCounter -> flow iceprog "RgbCounter" rgbCounter =<< getDataFileName ("data" </> "RgbCounter" <.> "pcf")
     RgbCycle   -> flow iceprog "RgbCycle" rgbCycle =<< getDataFileName ("data" </> "RgbCycle" <.> "pcf")
-    Hello      -> flow iceprog "Hello" (compile hello) =<< getDataFileName ("data" </> "Hello" <.> "pcf")
+    Hello      -> flow iceprog "Hello" (handleErr $ compile hello) =<< getDataFileName ("data" </> "Hello" <.> "pcf")
   CliProve cli -> do
     lp <- fromJust <$> case input cli of
       FileInput f -> parseMaybe (parse <* eof) <$> TIO.readFile f
@@ -38,10 +38,13 @@ app = \case
   CliCom -> com "/dev/ttyUSB0"
 
 rgbCounter :: File
-rgbCounter = compile prog
+rgbCounter = handleErr $ compile prog
 
 rgbCycle :: File
-rgbCycle = compile cycleProg
+rgbCycle = handleErr $ compile cycleProg
+
+handleErr :: Either Err File -> File
+handleErr = either (error . show) id
 
 com :: String -> IO ()
 com portPath = hWithSerial portPath serialPortSettings $ \hndl -> do

--- a/lib/Bayeux/Signal.hs
+++ b/lib/Bayeux/Signal.hs
@@ -8,7 +8,6 @@ import qualified Bayeux.Rtl as Rtl
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Writer
-import Data.Bits
 
 data Sig = Sig
   { spec   :: SigSpec
@@ -18,7 +17,7 @@ data Sig = Sig
   deriving (Eq, Read, Show)
 
 class MonadSignal m where
-  val :: FiniteBits a => a -> m Sig
+  val :: Value -> m Sig
 
   process :: Bool -> Integer -> (Sig -> m Sig) -> m Sig
   at :: Sig -> Integer -> m Sig
@@ -69,9 +68,9 @@ class MonadSignal m where
         -> m Sig
 
 instance MonadSignal Rtl where
-  val v = return $ Sig
-    { spec = SigSpecConstant $ ConstantValue $ binaryValue v
-    , size = fromIntegral $ finiteBitSize v
+  val v@(Value s _) = return $ Sig
+    { spec = SigSpecConstant $ ConstantValue v
+    , size = s
     , signed = False
     }
 

--- a/lib/Bayeux/Signal.hs
+++ b/lib/Bayeux/Signal.hs
@@ -1,0 +1,121 @@
+module Bayeux.Signal
+  ( Sig(..)
+  , MonadSignal(..)
+  ) where
+
+import Bayeux.Rtl
+import qualified Bayeux.Rtl as Rtl
+import Control.Monad
+import Control.Monad.Writer
+import Data.Bits
+
+data Sig = Sig
+  { spec   :: SigSpec
+  , size   :: Integer
+  , signed :: Bool
+  }
+  deriving (Eq, Read, Show)
+
+class MonadSignal m where
+  val :: FiniteBits a => a -> m Sig
+
+  process :: Bool -> Integer -> (Sig -> m Sig) -> m Sig
+  at :: Sig -> Integer -> m Sig
+
+  -- | If S == 1 then B else A
+  mux :: Sig   -- ^ S
+      -> Sig   -- ^ A
+      -> Sig   -- ^ B
+      -> m Sig -- ^ Y
+
+  unary :: ( CellId
+             -> Bool
+             -> Integer
+             -> Integer
+             -> SigSpec
+             -> SigSpec
+             -> Cell
+           )
+        -> Sig
+        -> m Sig
+  binary :: ( CellId
+              -> Bool
+              -> Integer
+              -> Bool
+              -> Integer
+              -> Integer
+              -> SigSpec
+              -> SigSpec
+              -> SigSpec
+              -> Cell
+            )
+         -> Sig
+         -> Sig
+         -> m Sig
+
+  shift :: ( CellId
+             -> Bool
+             -> Integer
+             -> Integer
+             -> Integer
+             -> SigSpec
+             -> SigSpec
+             -> SigSpec
+             -> Cell
+           )
+        -> Sig
+        -> Sig
+        -> m Sig
+
+instance MonadSignal Rtl where
+  val v = return $ Sig
+    { spec = SigSpecConstant $ ConstantValue $ binaryValue v
+    , size = fromIntegral $ finiteBitSize v
+    , signed = False
+    }
+
+  process s w f = do
+    old <- freshWire w
+    let oldSig = Sig{ spec = old, size = w, signed = s }
+    procStmt <- freshProcStmt
+    srcSig <- f oldSig
+    when (size srcSig /= w) $ error "size mismatch"
+    tell [ModuleBodyProcess $ updateP procStmt (DestSigSpec old) (SrcSigSpec (spec srcSig))]
+    return oldSig
+
+  at s i
+    | i >= size s = error "size mismatch"
+    | otherwise   = do
+        t <- Rtl.at (spec s) i
+        return Sig{ spec = t, size = 1, signed = False }
+
+  mux s a b
+    | not valid = error "size mismatch"
+    | otherwise = do
+        y <- Rtl.mux (size a) (spec s) (spec a) (spec b)
+        return Sig{ spec = y, size = size a, signed = signed a }
+    where
+      valid = and
+        [ size s == 1 && signed s == False
+        , size a == size b && signed a == signed b
+        ]
+
+  unary cFn a = do
+    y <- Rtl.unary cFn (signed a) (size a) (size a) (spec a)
+    return Sig{ spec = y, size = size a, signed = signed a }
+
+  binary cFn a b
+    | not valid = error "size mismatch"
+    | otherwise = do
+        y <- Rtl.binary cFn (signed a) (size a) (signed b) (size b) (size a) (spec a) (spec b)
+        return Sig{ spec = y, size = size a, signed = signed a }
+    where
+      valid = signed a == signed b && size a == size b
+
+  shift cFn a b
+    | not valid = error "signed shift"
+    | otherwise = do
+        y <- Rtl.shift cFn (signed a) (size a) (size b) (size a) (spec a) (spec b)
+        return Sig{ spec = y, size = size a, signed = signed a }
+    where
+      valid = not $ signed b

--- a/test/Test/Bayeux/Rgb.hs
+++ b/test/Test/Bayeux/Rgb.hs
@@ -21,14 +21,17 @@ import Test.Tasty.Golden
 tests :: [TestTree]
 tests =
   [ testGroup "pretty"
-      [ prettyTest "rgbcounter" $ compile prog
-      , prettyTest "rgbcycle"   $ compile cycleProg
+      [ prettyTest "rgbcounter" $ handleErr $ compile prog
+      , prettyTest "rgbcycle"   $ handleErr $ compile cycleProg
       ]
   , testGroup "synth"
-      [ synthTest "rgbcounter" $ compile prog
-      , synthTest "rgbcycle"   $ compile cycleProg
+      [ synthTest "rgbcounter" $ handleErr $ compile prog
+      , synthTest "rgbcycle"   $ handleErr $ compile cycleProg
       ]
   ]
+
+handleErr :: Either Err File -> File
+handleErr = either (error . show) id
 
 prettyTest :: Pretty a => TestName -> a -> TestTree
 prettyTest n = goldenVsString n (curDir </> n <.> "pretty")

--- a/test/Test/Bayeux/Uart.hs
+++ b/test/Test/Bayeux/Uart.hs
@@ -21,12 +21,15 @@ import Test.Tasty.Golden
 tests :: [TestTree]
 tests =
   [ testGroup "pretty"
-      [ prettyTest "hello" $ compile hello
+      [ prettyTest "hello" $ handleErr $ compile hello
       ]
   , testGroup "synth"
-      [ synthTest "hello" $ compile hello
+      [ synthTest "hello" $ handleErr $ compile hello
       ]
   ]
+
+handleErr :: Either Err File -> File
+handleErr = either (error . show) id
 
 prettyTest :: Pretty a => TestName -> a -> TestTree
 prettyTest n = goldenVsString n (curDir </> n <.> "pretty")


### PR DESCRIPTION
MonadRtl has explicit sizes for all connections. Extend the language with MonadSignal which introduces `Sig` type for tracking wire width and sign implicitly.