### PR TITLE
Define `ifm` using muxes

### DIFF
--- a/lib/Bayeux/Uart.hs
+++ b/lib/Bayeux/Uart.hs
@@ -49,8 +49,13 @@ instance MonadUart Rtl where
           , notDone      `thenm` buf
           , elsem buf'
           ]
-    txOut <- flip (mux isStartFrame) (zero 1) =<< flip (mux isEndFrame) one =<< buf `at` 0
-    out "\\tx" =<< mux isStart txOut one
+    e <- buf `at` 0
+    out "\\tx" =<< ifm
+      [ isStart      `thenm` one
+      , isStartFrame `thenm` zero 1
+      , isEndFrame   `thenm` one
+      , elsem e
+      ]
     txFsm' <- bar =<< ctrDone `conj` isEndFrame
     mux isStart txFsm' $ valid byte
 

--- a/lib/Bayeux/Uart.hs
+++ b/lib/Bayeux/Uart.hs
@@ -44,13 +44,11 @@ instance MonadUart Rtl where
     isEndFrame   <- eq txIx nine
     buf <- process False 8 $ \buf -> do
       buf' <- shr buf one
-      ifm [ isStartFrame `thenm` buf
+      ifm [ isStart      `thenm` value byte
+          , isStartFrame `thenm` buf
           , notDone      `thenm` buf
-          , isStart      `thenm` value byte
           , elsem buf'
           ]
---      buf' <- flip (mux isStartFrame) buf =<< mux ctrDone buf =<< shr buf one
---      mux isStart buf' $ value byte
     txOut <- flip (mux isStartFrame) (zero 1) =<< flip (mux isEndFrame) one =<< buf `at` 0
     out "\\tx" =<< mux isStart txOut one
     txFsm' <- bar =<< ctrDone `conj` isEndFrame

--- a/test/Test/Bayeux/Rgb/golden/rgbcycle.pretty
+++ b/test/Test/Bayeux/Rgb/golden/rgbcycle.pretty
@@ -65,79 +65,76 @@ module \top
 
   wire width 1 \wire12
   connect \wire12 \wire10 [0]
-  wire width 32 \wire13
-  wire width 32 \wire15
+  wire width 1 \wire13
 
-  cell $eq $cell16
+  cell $not $cell14
     parameter \A_SIGNED 0
-    parameter \A_WIDTH 32
-    parameter \B_SIGNED 0
-    parameter \B_WIDTH 32
-    parameter \Y_WIDTH 32
-    connect \A \wire13
-    connect \B 32'00000000000000000000000000000010
-    connect \Y \wire15
+    parameter \A_WIDTH 1
+    parameter \Y_WIDTH 1
+    connect \A \wire12
+    connect \Y \wire13
   end
 
-  wire width 1 \wire17
-  connect \wire17 \wire15 [0]
+  wire width 1 \wire15
+  connect \wire15 \wire13 [0]
+  wire width 32 \wire16
   wire width 32 \wire18
 
-  cell $add $cell19
+  cell $eq $cell19
     parameter \A_SIGNED 0
     parameter \A_WIDTH 32
     parameter \B_SIGNED 0
     parameter \B_WIDTH 32
     parameter \Y_WIDTH 32
-    connect \A \wire13
-    connect \B 32'00000000000000000000000000000001
+    connect \A \wire16
+    connect \B 32'00000000000000000000000000000010
     connect \Y \wire18
   end
 
-  wire width 32 \wire20
+  wire width 1 \wire20
+  connect \wire20 \wire18 [0]
+  wire width 32 \wire21
 
-  cell $mux $cell21
+  cell $add $cell22
+    parameter \A_SIGNED 0
+    parameter \A_WIDTH 32
+    parameter \B_SIGNED 0
+    parameter \B_WIDTH 32
+    parameter \Y_WIDTH 32
+    connect \A \wire16
+    connect \B 32'00000000000000000000000000000001
+    connect \Y \wire21
+  end
+
+  wire width 32 \wire23
+
+  cell $mux $cell24
     parameter \WIDTH 32
-    connect \A \wire18
+    connect \A \wire21
     connect \B 32'00000000000000000000000000000000
-    connect \S \wire17
-    connect \Y \wire20
+    connect \S \wire20
+    connect \Y \wire23
   end
 
-  wire width 32 \wire22
+  wire width 32 \wire25
 
-  cell $mux $cell23
+  cell $mux $cell26
     parameter \WIDTH 32
-    connect \A \wire13
-    connect \B \wire20
-    connect \S \wire12
-    connect \Y \wire22
+    connect \A \wire23
+    connect \B \wire16
+    connect \S \wire15
+    connect \Y \wire25
   end
 
 
-  process $proc14
+  process $proc17
     
 
 
     sync posedge \clk
-      update \wire13 \wire22
+      update \wire16 \wire25
   end
 
-  wire width 32 \wire24
-
-  cell $eq $cell25
-    parameter \A_SIGNED 0
-    parameter \A_WIDTH 32
-    parameter \B_SIGNED 0
-    parameter \B_WIDTH 32
-    parameter \Y_WIDTH 32
-    connect \A \wire13
-    connect \B 32'00000000000000000000000000000000
-    connect \Y \wire24
-  end
-
-  wire width 1 \wire26
-  connect \wire26 \wire24 [0]
   wire width 32 \wire27
 
   cell $eq $cell28
@@ -146,8 +143,8 @@ module \top
     parameter \B_SIGNED 0
     parameter \B_WIDTH 32
     parameter \Y_WIDTH 32
-    connect \A \wire13
-    connect \B 32'00000000000000000000000000000001
+    connect \A \wire16
+    connect \B 32'00000000000000000000000000000000
     connect \Y \wire27
   end
 
@@ -161,13 +158,28 @@ module \top
     parameter \B_SIGNED 0
     parameter \B_WIDTH 32
     parameter \Y_WIDTH 32
-    connect \A \wire13
-    connect \B 32'00000000000000000000000000000010
+    connect \A \wire16
+    connect \B 32'00000000000000000000000000000001
     connect \Y \wire30
   end
 
   wire width 1 \wire32
   connect \wire32 \wire30 [0]
+  wire width 32 \wire33
+
+  cell $eq $cell34
+    parameter \A_SIGNED 0
+    parameter \A_WIDTH 32
+    parameter \B_SIGNED 0
+    parameter \B_WIDTH 32
+    parameter \Y_WIDTH 32
+    connect \A \wire16
+    connect \B 32'00000000000000000000000000000010
+    connect \Y \wire33
+  end
+
+  wire width 1 \wire35
+  connect \wire35 \wire33 [0]
   wire output 2 \red
   wire output 3 \green
   wire output 4 \blue
@@ -179,11 +191,11 @@ module \top
     parameter \RGB2_CURRENT "0b111111"
     connect \CURREN 1'1
     connect \RGB0 \red
-    connect \RGB0PWM \wire26
+    connect \RGB0PWM \wire29
     connect \RGB1 \green
-    connect \RGB1PWM \wire29
+    connect \RGB1PWM \wire32
     connect \RGB2 \blue
-    connect \RGB2PWM \wire32
+    connect \RGB2PWM \wire35
     connect \RGBLEDEN 1'1
   end
 

--- a/test/Test/Bayeux/Uart/golden/hello.pretty
+++ b/test/Test/Bayeux/Uart/golden/hello.pretty
@@ -123,9 +123,21 @@ module \top
 
   wire width 1 \wire29
   connect \wire29 \wire27 [0]
-  wire width 4 \wire30
+  wire width 1 \wire30
 
-  cell $add $cell31
+  cell $not $cell31
+    parameter \A_SIGNED 0
+    parameter \A_WIDTH 1
+    parameter \Y_WIDTH 1
+    connect \A \wire24
+    connect \Y \wire30
+  end
+
+  wire width 1 \wire32
+  connect \wire32 \wire30 [0]
+  wire width 4 \wire33
+
+  cell $add $cell34
     parameter \A_SIGNED 0
     parameter \A_WIDTH 4
     parameter \B_SIGNED 0
@@ -133,27 +145,27 @@ module \top
     parameter \Y_WIDTH 4
     connect \A \wire25
     connect \B 4'0001
-    connect \Y \wire30
+    connect \Y \wire33
   end
 
-  wire width 4 \wire32
+  wire width 4 \wire35
 
-  cell $mux $cell33
+  cell $mux $cell36
     parameter \WIDTH 4
-    connect \A \wire30
+    connect \A \wire33
     connect \B 4'0000
     connect \S \wire29
-    connect \Y \wire32
+    connect \Y \wire35
   end
 
-  wire width 4 \wire34
+  wire width 4 \wire37
 
-  cell $mux $cell35
+  cell $mux $cell38
     parameter \WIDTH 4
-    connect \A \wire25
-    connect \B \wire32
-    connect \S \wire24
-    connect \Y \wire34
+    connect \A \wire35
+    connect \B \wire25
+    connect \S \wire32
+    connect \Y \wire37
   end
 
 
@@ -162,24 +174,9 @@ module \top
 
 
     sync posedge \clk
-      update \wire25 \wire34
+      update \wire25 \wire37
   end
 
-  wire width 4 \wire36
-
-  cell $eq $cell37
-    parameter \A_SIGNED 0
-    parameter \A_WIDTH 4
-    parameter \B_SIGNED 0
-    parameter \B_WIDTH 4
-    parameter \Y_WIDTH 4
-    connect \A \wire25
-    connect \B 4'0000
-    connect \Y \wire36
-  end
-
-  wire width 1 \wire38
-  connect \wire38 \wire36 [0]
   wire width 4 \wire39
 
   cell $eq $cell40
@@ -189,132 +186,147 @@ module \top
     parameter \B_WIDTH 4
     parameter \Y_WIDTH 4
     connect \A \wire25
-    connect \B 4'1001
+    connect \B 4'0000
     connect \Y \wire39
   end
 
   wire width 1 \wire41
   connect \wire41 \wire39 [0]
-  wire width 8 \wire42
-  wire width 8 \wire44
+  wire width 4 \wire42
 
-  cell $shr $cell45
+  cell $eq $cell43
+    parameter \A_SIGNED 0
+    parameter \A_WIDTH 4
+    parameter \B_SIGNED 0
+    parameter \B_WIDTH 4
+    parameter \Y_WIDTH 4
+    connect \A \wire25
+    connect \B 4'1001
+    connect \Y \wire42
+  end
+
+  wire width 1 \wire44
+  connect \wire44 \wire42 [0]
+  wire width 8 \wire45
+  wire width 8 \wire47
+
+  cell $shr $cell48
     parameter \A_SIGNED 0
     parameter \A_WIDTH 8
     parameter \B_SIGNED 0
     parameter \B_WIDTH 1
     parameter \Y_WIDTH 8
-    connect \A \wire42
+    connect \A \wire45
     connect \B 1'1
-    connect \Y \wire44
+    connect \Y \wire47
   end
 
-  wire width 8 \wire46
+  wire width 8 \wire49
 
-  cell $mux $cell47
+  cell $mux $cell50
     parameter \WIDTH 8
-    connect \A \wire42
-    connect \B \wire44
+    connect \A \wire45
+    connect \B \wire47
     connect \S \wire24
-    connect \Y \wire46
+    connect \Y \wire49
   end
 
-  wire width 8 \wire48
+  wire width 8 \wire51
 
-  cell $mux $cell49
+  cell $mux $cell52
     parameter \WIDTH 8
-    connect \A \wire46
-    connect \B \wire42
-    connect \S \wire38
-    connect \Y \wire48
+    connect \A \wire49
+    connect \B \wire45
+    connect \S \wire41
+    connect \Y \wire51
   end
 
-  wire width 8 \wire50
+  wire width 8 \wire53
 
-  cell $mux $cell51
+  cell $mux $cell54
     parameter \WIDTH 8
-    connect \A \wire48
+    connect \A \wire51
     connect \B 8'01100001
     connect \S \wire10
-    connect \Y \wire50
+    connect \Y \wire53
   end
 
 
-  process $proc43
+  process $proc46
     
 
 
     sync posedge \clk
-      update \wire42 \wire50
-  end
-
-  wire width 1 \wire52
-  connect \wire52 \wire42 [0]
-  wire width 1 \wire53
-
-  cell $mux $cell54
-    parameter \WIDTH 1
-    connect \A \wire52
-    connect \B 1'1
-    connect \S \wire41
-    connect \Y \wire53
+      update \wire45 \wire53
   end
 
   wire width 1 \wire55
+  connect \wire55 \wire45 [0]
+  wire width 1 \wire56
 
-  cell $mux $cell56
-    parameter \WIDTH 1
-    connect \A \wire53
-    connect \B 1'0
-    connect \S \wire38
-    connect \Y \wire55
-  end
-
-  wire width 1 \wire57
-
-  cell $mux $cell58
+  cell $mux $cell57
     parameter \WIDTH 1
     connect \A \wire55
     connect \B 1'1
-    connect \S \wire10
-    connect \Y \wire57
+    connect \S \wire44
+    connect \Y \wire56
   end
 
-  wire output 59 \tx
-  connect \tx \wire57
+  wire width 1 \wire58
+
+  cell $mux $cell59
+    parameter \WIDTH 1
+    connect \A \wire56
+    connect \B 1'0
+    connect \S \wire41
+    connect \Y \wire58
+  end
+
   wire width 1 \wire60
 
-  cell $and $cell61
+  cell $mux $cell61
+    parameter \WIDTH 1
+    connect \A \wire58
+    connect \B 1'1
+    connect \S \wire10
+    connect \Y \wire60
+  end
+
+  wire output 62 \tx
+  connect \tx \wire60
+  wire width 1 \wire63
+
+  cell $and $cell64
     parameter \A_SIGNED 0
     parameter \A_WIDTH 1
     parameter \B_SIGNED 0
     parameter \B_WIDTH 1
     parameter \Y_WIDTH 1
     connect \A \wire24
-    connect \B \wire41
-    connect \Y \wire60
+    connect \B \wire44
+    connect \Y \wire63
   end
 
-  wire width 1 \wire62
+  wire width 1 \wire65
 
-  cell $not $cell63
+  cell $not $cell66
     parameter \A_SIGNED 0
     parameter \A_WIDTH 1
     parameter \Y_WIDTH 1
-    connect \A \wire60
-    connect \Y \wire62
+    connect \A \wire63
+    connect \Y \wire65
   end
 
-  wire width 1 \wire64
-  connect \wire64 \wire62 [0]
-  wire width 1 \wire65
+  wire width 1 \wire67
+  connect \wire67 \wire65 [0]
+  wire width 1 \wire68
 
-  cell $mux $cell66
+  cell $mux $cell69
     parameter \WIDTH 1
-    connect \A \wire64
+    connect \A \wire67
     connect \B \wire5
     connect \S \wire10
-    connect \Y \wire65
+    connect \Y \wire68
   end
 
 
@@ -323,12 +335,12 @@ module \top
 
 
     sync posedge \clk
-      update \wire6 \wire65
+      update \wire6 \wire68
   end
 
-  wire width 32 \wire67
+  wire width 32 \wire70
 
-  cell $add $cell68
+  cell $add $cell71
     parameter \A_SIGNED 0
     parameter \A_WIDTH 32
     parameter \B_SIGNED 0
@@ -336,17 +348,17 @@ module \top
     parameter \Y_WIDTH 32
     connect \A \wire1
     connect \B 32'00000000000000000000000000000001
-    connect \Y \wire67
+    connect \Y \wire70
   end
 
-  wire width 32 \wire69
+  wire width 32 \wire72
 
-  cell $mux $cell70
+  cell $mux $cell73
     parameter \WIDTH 32
-    connect \A \wire67
+    connect \A \wire70
     connect \B 32'00000000000000000000000000000000
     connect \S \wire5
-    connect \Y \wire69
+    connect \Y \wire72
   end
 
 
@@ -355,7 +367,7 @@ module \top
 
 
     sync posedge \clk
-      update \wire1 \wire69
+      update \wire1 \wire72
   end
 
 end

--- a/test/Test/Bayeux/Uart/golden/hello.pretty
+++ b/test/Test/Bayeux/Uart/golden/hello.pretty
@@ -107,29 +107,29 @@ module \top
 
   wire width 1 \wire24
   connect \wire24 \wire22 [0]
-  wire width 4 \wire25
-  wire width 4 \wire27
+  wire width 1 \wire25
 
-  cell $eq $cell28
+  cell $not $cell26
+    parameter \A_SIGNED 0
+    parameter \A_WIDTH 1
+    parameter \Y_WIDTH 1
+    connect \A \wire24
+    connect \Y \wire25
+  end
+
+  wire width 1 \wire27
+  connect \wire27 \wire25 [0]
+  wire width 4 \wire28
+  wire width 4 \wire30
+
+  cell $eq $cell31
     parameter \A_SIGNED 0
     parameter \A_WIDTH 4
     parameter \B_SIGNED 0
     parameter \B_WIDTH 4
     parameter \Y_WIDTH 4
-    connect \A \wire25
+    connect \A \wire28
     connect \B 4'1001
-    connect \Y \wire27
-  end
-
-  wire width 1 \wire29
-  connect \wire29 \wire27 [0]
-  wire width 1 \wire30
-
-  cell $not $cell31
-    parameter \A_SIGNED 0
-    parameter \A_WIDTH 1
-    parameter \Y_WIDTH 1
-    connect \A \wire24
     connect \Y \wire30
   end
 
@@ -143,7 +143,7 @@ module \top
     parameter \B_SIGNED 0
     parameter \B_WIDTH 4
     parameter \Y_WIDTH 4
-    connect \A \wire25
+    connect \A \wire28
     connect \B 4'0001
     connect \Y \wire33
   end
@@ -154,7 +154,7 @@ module \top
     parameter \WIDTH 4
     connect \A \wire33
     connect \B 4'0000
-    connect \S \wire29
+    connect \S \wire32
     connect \Y \wire35
   end
 
@@ -163,18 +163,18 @@ module \top
   cell $mux $cell38
     parameter \WIDTH 4
     connect \A \wire35
-    connect \B \wire25
-    connect \S \wire32
+    connect \B \wire28
+    connect \S \wire27
     connect \Y \wire37
   end
 
 
-  process $proc26
+  process $proc29
     
 
 
     sync posedge \clk
-      update \wire25 \wire37
+      update \wire28 \wire37
   end
 
   wire width 4 \wire39
@@ -185,7 +185,7 @@ module \top
     parameter \B_SIGNED 0
     parameter \B_WIDTH 4
     parameter \Y_WIDTH 4
-    connect \A \wire25
+    connect \A \wire28
     connect \B 4'0000
     connect \Y \wire39
   end
@@ -200,7 +200,7 @@ module \top
     parameter \B_SIGNED 0
     parameter \B_WIDTH 4
     parameter \Y_WIDTH 4
-    connect \A \wire25
+    connect \A \wire28
     connect \B 4'1001
     connect \Y \wire42
   end
@@ -225,9 +225,9 @@ module \top
 
   cell $mux $cell50
     parameter \WIDTH 8
-    connect \A \wire45
-    connect \B \wire47
-    connect \S \wire24
+    connect \A \wire47
+    connect \B \wire45
+    connect \S \wire27
     connect \Y \wire49
   end
 


### PR DESCRIPTION
Similar to Haskell guards, `ifm` selects the first signal with a true condition:
```haskell
{-# LANGUAGE OverloadedLists #-}

f = ifm
  [ cond1 `thenm` res1
  , cond2 `thenm` res2
  , elsem $ res3
  ]
 ```
In `Rtl`, `ifm` is interpreted as a chain of muxes.