### PR TITLE
Improve value introduction

### DIFF
--- a/bayeux.cabal
+++ b/bayeux.cabal
@@ -32,7 +32,6 @@ library
                     , binary
                     , bytestring
                     , containers
-                    , derive-storable
                     , filepath
                     , megaparsec
                     , mtl

--- a/bayeux.cabal
+++ b/bayeux.cabal
@@ -24,11 +24,15 @@ library
                     , Bayeux.Signal
                     , Bayeux.Tableaux
                     , Bayeux.Uart
+                    , Bayeux.Width
     other-modules:    Paths_bayeux
     autogen-modules:  Paths_bayeux
     build-depends:    async
                     , base
+                    , binary
+                    , bytestring
                     , containers
+                    , derive-storable
                     , filepath
                     , megaparsec
                     , mtl

--- a/lib/Bayeux/Cell.hs
+++ b/lib/Bayeux/Cell.hs
@@ -22,7 +22,6 @@ import Bayeux.Rtl hiding (at, binary, unary, shift, shr)
 import Bayeux.Signal
 import Bayeux.Width
 import Control.Monad
-import Data.Bits hiding (shift)
 import Prelude hiding (and, not, or)
 
 -- | increment

--- a/lib/Bayeux/Cell.hs
+++ b/lib/Bayeux/Cell.hs
@@ -19,30 +19,31 @@ module Bayeux.Cell
 
 import Bayeux.Rtl hiding (at, binary, unary, shift, shr)
 import Bayeux.Signal
+import Bayeux.Width
 import Control.Monad
 import Data.Bits hiding (shift)
 import Prelude hiding (and, not, or)
 
 -- | increment
-inc :: FiniteBits a => MonadSignal m => Sig a -> m (Sig a)
+inc :: Width a => MonadSignal m => Sig a -> m (Sig a)
 inc a = binary addC a $ val True
 
 logicNot :: MonadSignal m => Sig Bool -> m (Sig Bool)
 logicNot = unary logicNotC
 
-not :: FiniteBits a => MonadSignal m => Sig a -> m (Sig a)
+not :: Width a => MonadSignal m => Sig a -> m (Sig a)
 not = unary notC
 
-add :: FiniteBits a => MonadSignal m => Sig a -> Sig a -> m (Sig a)
+add :: Width a => MonadSignal m => Sig a -> Sig a -> m (Sig a)
 add = binary addC
 
-and :: FiniteBits a => MonadSignal m => Sig a -> Sig a -> m (Sig a)
+and :: Width a => MonadSignal m => Sig a -> Sig a -> m (Sig a)
 and = binary andC
 
-eq :: FiniteBits a => Monad m => MonadSignal m => Sig a -> Sig a -> m (Sig Bool)
+eq :: Width a => Monad m => MonadSignal m => Sig a -> Sig a -> m (Sig Bool)
 eq a = flip at 0 <=< eq' a
   where
-    eq' :: FiniteBits a => MonadSignal m => Sig a -> Sig a -> m (Sig a)
+    eq' :: Width a => MonadSignal m => Sig a -> Sig a -> m (Sig a)
     eq' = binary eqC
 
 logicAnd :: MonadSignal m => Sig Bool -> Sig Bool -> m (Sig Bool)
@@ -51,8 +52,8 @@ logicAnd = binary logicAndC
 logicOr :: MonadSignal m => Sig Bool -> Sig Bool -> m (Sig Bool)
 logicOr = binary logicOrC
 
-or :: FiniteBits a => MonadSignal m => Sig a -> Sig a -> m (Sig a)
+or :: Width a => MonadSignal m => Sig a -> Sig a -> m (Sig a)
 or = binary orC
 
-shr :: FiniteBits a => FiniteBits b => MonadSignal m => Sig a -> Sig b -> m (Sig a)
+shr :: Width a => Width b => MonadSignal m => Sig a -> Sig b -> m (Sig a)
 shr = shift shrC

--- a/lib/Bayeux/Rgb.hs
+++ b/lib/Bayeux/Rgb.hs
@@ -58,7 +58,7 @@ cycleProg = do
     t1Sec <- timer === val 12000000
     timer' <- C.inc timer
     mux t1Sec timer' zero
-  tNEqZ <- C.logicNot =<< t `C.eq` zero
+  tNEqZ <- C.logicNot =<< t === zero
   c <- process $ \color -> do
     cEqBlue <- color === val Blue
     c' <- C.inc color

--- a/lib/Bayeux/Rgb.hs
+++ b/lib/Bayeux/Rgb.hs
@@ -40,6 +40,9 @@ prog = do
   b <- c `at` 22
   outputRgb r g b
 
+--data Color = Red | Green | Blue
+--  deriving (Binary, Eq, Read, Show, Width)
+
 cycleProg :: Monad m => MonadSignal m => MonadRgb m => m ()
 cycleProg = do
   let zero = val (0 :: Word32)

--- a/lib/Bayeux/Rgb.hs
+++ b/lib/Bayeux/Rgb.hs
@@ -17,7 +17,6 @@ import Bayeux.Signal
 import Bayeux.Width
 import Control.Monad.Writer
 import Data.Binary
-import Data.Word
 import GHC.Generics
 
 -- | PWM inputs, width=1

--- a/lib/Bayeux/Signal.hs
+++ b/lib/Bayeux/Signal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs               #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+
 module Bayeux.Signal
   ( Sig(..)
   , val

--- a/lib/Bayeux/Signal.hs
+++ b/lib/Bayeux/Signal.hs
@@ -25,9 +25,6 @@ import Data.Maybe
 import Data.String
 import GHC.Generics
 
-data MyType = Foo Word16 Word32
-  deriving (Binary, Eq, Generic, Read, Show, Width)
-
 newtype Sig a = Sig{ spec :: SigSpec }
   deriving (Eq, IsString, Read, Show)
 
@@ -35,18 +32,11 @@ instance Width a => Width (Sig a) where
   width _ = width (undefined :: a)
 
 val :: forall a. Binary a => Width a => a -> Sig a
-val = Sig
-        . SigSpecConstant
-        . ConstantValue
-        . Value (width (undefined :: a))
-        . foldMap binaryDigits
-        . LB.unpack
-        . encode
+val v = let bs = foldMap binaryDigits $ LB.unpack $ encode v
+        in Sig $ SigSpecConstant $ ConstantValue $ Value w $ drop (length bs - fromIntegral w) bs
+  where
+    w = width (undefined :: a)
 
-{-
-val :: FiniteBits a => a -> Sig a
-val = Sig . SigSpecConstant . ConstantValue . binaryValue
--}
 instance Bits a => Bits (Sig a) where
   isSigned _ = isSigned (undefined :: a)
 

--- a/lib/Bayeux/Width.hs
+++ b/lib/Bayeux/Width.hs
@@ -1,43 +1,9 @@
-{-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators     #-}
-
 module Bayeux.Width where
 
 import Data.Word
-import GHC.Generics
-
-class Width1 f where
-  width1 :: f p -> Integer
-
-defaultWidth :: (Generic a, Width1 (Rep a)) => a -> Integer
-defaultWidth = width1 . from
-
-instance Width1 V1 where
-  width1 _ = 0
-
-instance Width1 U1 where
-  width1 _ = 1
-
-instance Width c => Width1 (K1 i c) where
-  width1 _ = width (undefined :: c)
-
-instance Width1 f => Width1 (M1 i c f) where
-  width1 (M1 x) = width1 x
-
-instance (Width1 a, Width1 b) => Width1 (a :+: b) where
-  width1 (L1 x) = 1 + width1 x
-  width1 (R1 x) = 1 + width1 x
-
-instance (Width1 a, Width1 b) => Width1 (a :*: b) where
-  width1 (a :*: b) = width1 a + width1 b
 
 class Width a where
   width :: a -> Integer
-  default width :: (Generic a, Width1 (Rep a)) => a -> Integer
-  width = defaultWidth
 
 instance Width Bool where
   width _ = 1

--- a/lib/Bayeux/Width.hs
+++ b/lib/Bayeux/Width.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators     #-}
+
+module Bayeux.Width where
+
+import Data.Word
+import GHC.Generics
+
+class Width1 f where
+  width1 :: f p -> Integer
+
+defaultWidth :: (Generic a, Width1 (Rep a)) => a -> Integer
+defaultWidth = width1 . from
+
+instance Width1 V1 where
+  width1 _ = 0
+
+instance Width1 U1 where
+  width1 _ = 1
+
+instance Width c => Width1 (K1 i c) where
+  width1 _ = width (undefined :: c)
+
+instance Width1 f => Width1 (M1 i c f) where
+  width1 (M1 x) = width1 x
+
+instance (Width1 a, Width1 b) => Width1 (a :+: b) where
+  width1 (L1 x) = 1 + width1 x
+  width1 (R1 x) = 1 + width1 x
+
+instance (Width1 a, Width1 b) => Width1 (a :*: b) where
+  width1 (a :*: b) = width1 a + width1 b
+
+class Width a where
+  width :: a -> Integer
+  default width :: (Generic a, Width1 (Rep a)) => a -> Integer
+  width = defaultWidth
+{-
+instance Width (V1 p) where
+  width _ = 0
+
+instance Width (U1 p) where
+  width _ = 1
+
+instance Width (K1 i c p) where
+  width _ = 1
+
+instance Width (f p) => Width (M1 i c f p) where
+  width (M1 x) = width x
+
+instance (Width (a p), Width (b p)) => Width ((a :+: b) p) where
+  width (L1 x) = width x
+  width (R1 x) = width x
+
+instance (Width (a p), Width (b p)) => Width ((a :*: b) p) where
+  width (a :*: b) = width a + width b
+-}
+instance Width Bool where
+  width _ = 1
+
+instance Width Word8 where
+  width _ = 8
+
+instance Width Word16 where
+  width _ = 16
+
+instance Width Word32 where
+  width _ = 32
+
+instance Width Word64 where
+  width _ = 64

--- a/lib/Bayeux/Width.hs
+++ b/lib/Bayeux/Width.hs
@@ -38,26 +38,7 @@ class Width a where
   width :: a -> Integer
   default width :: (Generic a, Width1 (Rep a)) => a -> Integer
   width = defaultWidth
-{-
-instance Width (V1 p) where
-  width _ = 0
 
-instance Width (U1 p) where
-  width _ = 1
-
-instance Width (K1 i c p) where
-  width _ = 1
-
-instance Width (f p) => Width (M1 i c f p) where
-  width (M1 x) = width x
-
-instance (Width (a p), Width (b p)) => Width ((a :+: b) p) where
-  width (L1 x) = width x
-  width (R1 x) = width x
-
-instance (Width (a p), Width (b p)) => Width ((a :*: b) p) where
-  width (a :*: b) = width a + width b
--}
 instance Width Bool where
   width _ = 1
 


### PR DESCRIPTION
Add `Width` typeclass, remove partial Bits and FiniteBits instances. Introduce values using `val` function constrained by `Binary`. Build more complex data structures and easily serialize them as a bus using Binary library and Generics.